### PR TITLE
Fixed OSX/Darwin link status property and parsing

### DIFF
--- a/ifconfig_examples/darwin.txt
+++ b/ifconfig_examples/darwin.txt
@@ -9,9 +9,11 @@ en0: flags=8863<UP,BROADCAST,SMART,RUNNING,SIMPLEX,MULTICAST> mtu 1500
 	inet 192.168.0.14 netmask 0xffffff00 broadcast 192.168.0.255
 	inet6 2001:5c0:8116::203:93ff:fe0a:1676 prefixlen 64 autoconf 
 	ether 00:03:93:0a:16:76 
-	media: autoselect (100baseTX <full-duplex>) status: active
+	media: autoselect (100baseTX <full-duplex>)
+	status: active
 	supported media: none autoselect 10baseT/UTP <half-duplex> 10baseT/UTP <full-duplex> 10baseT/UTP <full-duplex,hw-loopback> 100baseTX <half-duplex> 100baseTX <full-duplex> 100baseTX <full-duplex,hw-loopback>
 fw0: flags=8822<BROADCAST,SMART,SIMPLEX,MULTICAST> mtu 2030
 	lladdr 00:03:93:ff:fe:0a:16:76 
-	media: autoselect <full-duplex> status: inactive
+	media: autoselect <full-duplex>
+	status: inactive
 	supported media: autoselect <full-duplex>

--- a/lib/ifconfig/bsd/interface_types.rb
+++ b/lib/ifconfig/bsd/interface_types.rb
@@ -27,6 +27,8 @@ class NetworkAdapter
         when /^\s*enabled=/
           # NetBSD uses "enabled="
           parse_capabilities(line)
+        when /^\s*status:/
+          parse_status(line)
       end
     }
   end
@@ -48,7 +50,15 @@ class NetworkAdapter
   def parse_flags(line)
     flags = line.match(/\<(\S+)\>/i)[1]
     @flags = flags.strip.split(',')
-    @status = true if @flags.include?('UP')
+  end
+
+  # parses the "status: active" line
+  #
+  def parse_status(line)
+    match = line.match(/status: (\S+)/)
+    if match
+      @status = match[1]
+    end
   end
 
   # Parses networks on an interface based on the first token in the line.

--- a/lib/ifconfig/common/interface_types.rb
+++ b/lib/ifconfig/common/interface_types.rb
@@ -4,7 +4,7 @@ class NetworkAdapter
   def initialize(name, ifacetxt, netstattxt=nil)
     @name = name
     @ifconfig = ifacetxt
-    @status = false
+    @status = nil
     @protos = ['inet','inet6','IPX/Ethernet II',
                'IPX/Ethernet SNAP',
                'IPX/Ethernet 802.2',
@@ -60,7 +60,11 @@ class NetworkAdapter
   end
 
   def up?
-    return status
+    return flags.include? "UP"
+  end
+
+  def link_up?
+    return @status == "active"
   end
 
   # returns array of arrays
@@ -119,7 +123,7 @@ class NetworkAdapter
     s += " Fib: #{@fib}\n" if @fib != 0
     s += " Lagg Proto: #{@laggproto}\n" if @laggproto
     s += " Lagg Children: #{@lagg_children}\n" if @lagg_children
-    s += " Status: UP" if self.status
+    s += " Status: #{@status}"
     return s
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,4 +1,6 @@
 $:.unshift File.expand_path('../lib', File.dirname(__FILE__))
 require 'ifconfig'
-require 'test/unit'
+require 'minitest/autorun'
 require 'pp'
+
+Test = Minitest

--- a/test/unit/tc_darwin.rb
+++ b/test/unit/tc_darwin.rb
@@ -38,4 +38,10 @@ class TC_DarwinTest < Test::Unit::TestCase
 
   end
 
+  def test_link_status
+    assert(@cfg['en0'].status == 'active' &&
+          !@cfg['fw0'].status == 'inactive',
+           "Failed to parse link status")
+  end
+
 end


### PR DESCRIPTION
This will break code that relies on NetworkAdapter#status (incorrectly)
referring to flags instead of link status.
